### PR TITLE
Add cycle mode to `FastSessionDataLoader` for balanced session sampling

### DIFF
--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List, Iterator, Union, Tuple
+from typing import Dict, Any, Optional, List, Iterator, Union, Tuple, Sequence, Literal
 
 # inbuilt libraries
 import os
@@ -26,6 +26,15 @@ from torch.utils.data import ConcatDataset, Dataset, DataLoader, Sampler
 from .intervals import TimeInterval
 
 logger = logging.getLogger(__name__)
+
+
+def count_batches(indices: Sequence[Any], batch_size: int, drop_last: bool) -> int:
+    # Calculate number of batches
+    if drop_last:
+        num_batches = len(indices) // batch_size
+    else:
+        num_batches = (len(indices) + batch_size - 1) // batch_size
+    return num_batches
 
 
 def replace_nan_with_batch_mean(data: np.array) -> np.array:
@@ -385,8 +394,8 @@ class SessionBatchSampler(Sampler):
         self.seed = seed
 
         # Use its own RNG instance based on the provided seed
-        self.rng = np.random.RandomState(seed) if seed is not None else np.random.RandomState()
-        self.prv_rng_state = None
+        self.rng = np.random.RandomState(seed)
+        self.prv_rng_state = self.rng.get_state()
 
         # Get sessions
         self.session_names = list(dataset.session_indices.keys())
@@ -405,12 +414,7 @@ class SessionBatchSampler(Sampler):
         self.batches_per_session = {}
         total_batches = 0
         for session_name, indices in self.session_indices.items():
-            session_size = len(indices)
-            if drop_last:
-                num_batches = session_size // batch_size
-            else:
-                num_batches = (session_size + batch_size - 1) // batch_size
-
+            num_batches = count_batches(indices, batch_size, drop_last)
             self.batches_per_session[session_name] = num_batches
             total_batches += num_batches
 
@@ -439,7 +443,6 @@ class SessionBatchSampler(Sampler):
     
     def reset_state(self):
         """Reset the state of the sampler."""
-        # TODO: Should we reset the RNG state?
         self.consumed_sessions = []
 
     def get_state(self):
@@ -452,9 +455,8 @@ class SessionBatchSampler(Sampler):
     def set_state(self, state):
         """Restore the state of the sampler (including RNG state)."""
         self.prv_rng_state = state.get('prv_rng_state')
-        if self.prv_rng_state is not None and self.rng is not None:
+        if self.prv_rng_state is not None:
             self.rng.set_state(self.prv_rng_state)
-        # self.prv_rng_state = None
         self.consumed_sessions = state.get('consumed_sessions', [])
 
 
@@ -467,8 +469,18 @@ class FastSessionDataLoader:
     4. State is properly tracked and can be restored
     """
 
-    def __init__(self, dataset, batch_size=1, shuffle=False, num_workers=0,
-                 pin_memory=False, drop_last=False, seed=None, **kwargs):
+    def __init__(
+        self,
+        dataset,
+        batch_size=1,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=False,
+        drop_last=False,
+        cycle_mode: Literal['active', 'max'] = 'active',
+        seed=None,
+        **kwargs,
+    ):
         """
         Initialize optimized session dataloader.
 
@@ -490,6 +502,9 @@ class FastSessionDataLoader:
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.kwargs = kwargs
+        assert cycle_mode in ['active', 'max'], \
+            f"Invalid cycle mode: {cycle_mode}! Must be one of ['active', 'max']"
+        self.cycle_mode = cycle_mode
         # Create batch sampler
         self.batch_sampler = SessionBatchSampler(
             dataset=dataset,
@@ -551,11 +566,11 @@ class FastSessionDataLoader:
         """Reset the state of the dataloader."""
         self.current_batch = 0
         self.position_in_epoch = 0
+        self.batches_from_session = defaultdict(int)
+        self.active_sessions = set(self.session_names)
         for name in self.session_names:
             self.session_positions[name] = 0
             self.session_dataloaders[name].batch_sampler.reset_state()
-        self.batches_from_session = defaultdict(int)
-        self.active_sessions = set(self.session_names)
         self.batch_sampler.reset_state()
         self.dataset.reset_state()
 
@@ -581,19 +596,19 @@ class FastSessionDataLoader:
             return
 
         # Restore batch counter
-        self.current_batch = state.get('current_batch', 0)
+        current_batch = state.get('current_batch')
+        if current_batch is not None:
+            self.current_batch = current_batch
 
-        self.position_in_epoch = state.get('position_in_epoch', 0)
+        # Restore position in epoch
+        position_in_epoch = state.get('position_in_epoch')
+        if position_in_epoch is not None:
+            self.position_in_epoch = position_in_epoch
 
         # Restore session positions
         session_positions = state.get('session_positions')
         if session_positions:
             self.session_positions = session_positions
-
-        # # Restore RNG state for the main dataloader
-        # dataloader_rng_state = state.get('dataloader_rng_state')
-        # if dataloader_rng_state is not None and self.rng is not None:
-        #     self.rng.set_state(dataloader_rng_state)
 
         # Restore RNG state for the batch sampler
         batch_sampler_state = state.get('batch_sampler_state')
@@ -621,18 +636,37 @@ class FastSessionDataLoader:
         for session_name, dataloader in self.session_dataloaders.items():
             # Get sampler and reset its position
             sampler = dataloader.batch_sampler
-            if hasattr(sampler, 'set_position'):
-                position = self.session_positions.get(session_name, 0)
-                sampler.set_position(position)
             # Restore RNG state for each session sampler
             session_sampler_states = state.get('session_sampler_states', {})
             sampler_state = session_sampler_states.get(session_name)
             if sampler_state is not None and hasattr(sampler, 'set_state'):
                 sampler.set_state(sampler_state)
+            # Restore position for each session sampler from `self.session_positions`.
+            # NOTE: Required still for backwards compatibility (i.e. if `position` not
+            #  in `sampler_state`).
+            if hasattr(sampler, 'set_position'):
+                position = self.session_positions.get(session_name)
+                if position is not None:
+                    sampler.set_position(position)
         
-        self.dataset.set_state(state.get('dataset_state'), strict=strict)
+        # Restore dataset state
+        dataset_state = state.get('dataset_state')
+        if dataset_state is not None and hasattr(self.dataset, 'set_state'):
+            self.dataset.set_state(dataset_state, strict=strict)
 
         print(f"Restored dataloader state to batch {self.current_batch}")
+
+    def _get_next_batch(self, iterator: Iterator, session_name: str) -> Tuple[str, Any]:
+        """Update the counts of the dataloader."""
+        # Get the next batch from this session
+        batch = next(iterator)
+        # Update state tracking
+        self.current_batch += 1
+        self.session_positions[session_name] += 1
+        self.batches_from_session[session_name] += 1  # Update local dictionary
+        self.batch_sampler.consumed_sessions.append(session_name)
+        # Return the batch and the session name
+        return session_name, batch
 
     def __iter__(self):
         """
@@ -644,25 +678,21 @@ class FastSessionDataLoader:
         3. The epoch ends when the longest session is exhausted
         """
 
-        # Reset session positions if needed
-        for session_name in self.session_names:
-            if self.session_positions.get(session_name, 0) >= self.batches_per_session.get(session_name, 0):
-                self.session_positions[session_name] = 0
-
+        # TODO: `SessionSpecificSampler` now handles it's own position, can we remove this? @konstantin
         # Reset iterators with current positions
         session_iterators = {}
         for session_name, dataloader in self.session_dataloaders.items():
             # Reset sampler position
             sampler = dataloader.batch_sampler
             if hasattr(sampler, 'set_position'):
-                sampler.set_position(self.session_positions.get(session_name, 0))
+                sampler.set_position(self.session_positions[session_name])
 
-            # Create iterator
-            session_iterators[session_name] = iter(dataloader)
+        # Create iterators for each session
+        session_iterators = {s: iter(dl) for s, dl in self.session_dataloaders.items()}
 
         # Continue until we've gone through one full epoch
         # (i.e., until the longest session is exhausted)
-        while self.active_sessions and self.position_in_epoch < self.max_batches_per_session:
+        while self.position_in_epoch < self.max_batches_per_session:
 
             # Create a cycle order of sessions
             cycle_order = self.batch_sampler.get_session_cycle()
@@ -670,35 +700,34 @@ class FastSessionDataLoader:
             # Process one batch from each active session in this cycle
             for session_name in cycle_order:
                 # Skip if session is already exhausted
+                # NOTE: Only required when continuing training (in `active` mode)
+                #  because `SessionSpecificSampler` resets its state automatically.
                 if session_name not in self.active_sessions:
                     continue
 
-                # Skip if we've already processed all batches for this session in the current epoch
-                if self.batches_from_session[session_name] >= self.batches_per_session.get(session_name, 0):
-                    self.active_sessions.remove(session_name)
-                    continue
-
                 # Get iterator for this session
-                iterator = session_iterators.get(session_name)
-                if iterator is None:
-                    continue
+                assert session_name in session_iterators, \
+                    f"Session {session_name} not in `session_iterators`!"
+                iterator = session_iterators[session_name]
 
                 try:
-                    # Get the next batch from this session
-                    batch = next(iterator)
-
-                    # Update state tracking
-                    self.current_batch += 1
-                    self.session_positions[session_name] += 1
-                    self.batches_from_session[session_name] += 1  # Update local dictionary
-                    self.batch_sampler.consumed_sessions.append(session_name)
-
-                    # Yield session name and batch
-                    yield session_name, batch
-
+                    yield self._get_next_batch(iterator, session_name)
                 except StopIteration:
-                    # This session is exhausted for the current epoch
-                    self.active_sessions.remove(session_name)
+                    if self.cycle_mode == 'active':
+                        # This session is exhausted for the current epoch
+                        if session_name in self.active_sessions:
+                            self.active_sessions.remove(session_name)
+                    elif self.cycle_mode == 'max':
+                        # Reset iterator and try again. NOTE: `SessionSpecificSampler`
+                        #  resets its state automatically when `__iter__` expires.
+                        iterator = iter(self.session_dataloaders[session_name])
+                        session_iterators[session_name] = iterator
+                        yield self._get_next_batch(iterator, session_name)
+                    else:
+                        raise ValueError(
+                            f"Invalid cycle mode: {self.cycle_mode}! "
+                            f"Must be one of ['active', 'max']"
+                        )
 
             self.batch_sampler.consumed_sessions = []
 
@@ -730,69 +759,70 @@ class SessionSpecificSampler(Sampler):
         self.batch_size = batch_size
         self.drop_last = drop_last
         self.shuffle = shuffle
-        self.prv_rng_state = None
-        self.rng = np.random.RandomState(seed) if seed is not None else np.random.RandomState()
-
-        # Calculate number of batches
-        if drop_last:
-            self.num_batches = len(indices) // batch_size
-        else:
-            self.num_batches = (len(indices) + batch_size - 1) // batch_size
-
+        self.rng = np.random.RandomState(seed)
+        self.prv_rng_state = self.rng.get_state()
+        self.num_batches = count_batches(indices, batch_size, drop_last)
         # Track current position
         self.position = 0
+        # Shuffle indices
+        self.reset_state()
 
     def __len__(self):
         """Return the number of batches."""
         return self.num_batches
 
-    def set_position(self, position):
+    def set_position(self, position: int):
         """Set the current batch position."""
         self.position = position % self.num_batches if self.num_batches > 0 else 0
 
+    def shuffle_indices(self):
+        """Shuffle the indices."""
+        if self.shuffle:
+            self.prv_rng_state = self.rng.get_state()
+            self.rng.shuffle(self.indices)
+
     def reset_state(self):
         """Reset the state of the sampler."""
-        # TODO: Should we reset the RNG state?
+        # Re-shuffle indices if needed
+        self.shuffle_indices()
+        # Reset position
         self.position = 0
 
     def get_state(self):
         """Return the state of the sampler (including RNG state)."""
         return {
-            'prv_rng_state': self.prv_rng_state
+            'prv_rng_state': self.prv_rng_state,
+            'position': self.position,
         }
 
     def set_state(self, state):
         """Restore the state of the sampler (including RNG state)."""
         self.prv_rng_state = state.get('prv_rng_state')
-        if self.prv_rng_state is not None and self.rng is not None:
+        if self.prv_rng_state is not None:
             self.rng.set_state(self.prv_rng_state)
+            # shuffle indices with loaded RNG state
+            self.shuffle_indices()
+        position = state.get('position')
+        if position is not None:
+            self.position = position
 
     def __iter__(self):
         """
         Yield batches of indices starting from the current position.
         """
-        # Create shuffled indices if needed
-        if self.shuffle and self.rng is not None:
-            indices = self.indices.copy()
-            self.prv_rng_state = self.rng.get_state()
-            self.rng.shuffle(indices)
-        else:
-            indices = self.indices
-
         # Start from current position
         start_idx = self.position * self.batch_size
 
-        # If start_idx is out of bounds, stop iteration for this pass
-        if start_idx >= len(indices):
-            return  # Effectively yield from []
-
         # Generate batches from start_idx to end
-        for i in range(start_idx, len(indices), self.batch_size):
-            batch_indices = indices[i:i + self.batch_size]
+        for i in range(start_idx, len(self.indices), self.batch_size):
+            batch_indices = self.indices[i:i + self.batch_size]
 
             # Skip last batch if needed
             if self.drop_last and len(batch_indices) < self.batch_size:
                 continue
+
+            # Update position
+            self.position += 1
 
             yield batch_indices
         

--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -686,9 +686,14 @@ class FastSessionDataLoader:
         3. The epoch ends when the longest session is exhausted
         """
 
-        # Create iterators for each session. NOTE: Calling `iter(dl)` actually increments
-        #  sampler position by 2, so we do it before setting the position!
-        session_iterators = {s: iter(dl) for s, dl in self.session_dataloaders.items()}
+        # Create iterators for each session.
+        session_iterators = {}
+        for s, dl in self.session_dataloaders.items():
+            # NOTE: Calling `iter(dl)` actually increments sampler position by 2, so we
+            #  manually re-set the position to the pre-iteration value!
+            _pre_iter_position = dl.batch_sampler.position
+            session_iterators[s] = iter(dl)
+            dl.batch_sampler.set_position(_pre_iter_position)
 
         # Reset iterators with current positions
         for session_name, dataloader in self.session_dataloaders.items():
@@ -765,7 +770,8 @@ class SessionSpecificSampler(Sampler):
             shuffle: Whether to shuffle indices
             seed: Random seed for reproducibility
         """
-        self.indices = list(indices)  # Make a copy to avoid modification issues
+        self._original_indices = list(indices)  # Save a copy so we can shuffle from original state
+        self.indices = deepcopy(self._original_indices)
         self.batch_size = batch_size
         self.drop_last = drop_last
         self.shuffle = shuffle
@@ -789,6 +795,9 @@ class SessionSpecificSampler(Sampler):
         """Shuffle the indices."""
         if self.shuffle:
             self.prv_rng_state = self.rng.get_state()
+            # NOTE: We always shuffle from the original indices such that the shuffled result
+            #  only depends on the current RNG state, not on the previous state of the indices.
+            self.indices = deepcopy(self._original_indices)
             self.rng.shuffle(self.indices)
 
     def reset_state(self):
@@ -800,6 +809,8 @@ class SessionSpecificSampler(Sampler):
 
     def get_state(self):
         """Return the state of the sampler (including RNG state)."""
+        # NOTE: We don't save the indices! This requires that the reloaded sampler must be
+        #  initialized with the same indices *in the same order* as the original one.
         return {
             'prv_rng_state': self.prv_rng_state,
             'position': self.position,

--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -686,17 +686,16 @@ class FastSessionDataLoader:
         3. The epoch ends when the longest session is exhausted
         """
 
-        # TODO: `SessionSpecificSampler` now handles it's own position, can we remove this? @konstantin
+        # Create iterators for each session. NOTE: Calling `iter(dl)` actually increments
+        #  sampler position by 2, so we do it before setting the position!
+        session_iterators = {s: iter(dl) for s, dl in self.session_dataloaders.items()}
+
         # Reset iterators with current positions
-        session_iterators = {}
         for session_name, dataloader in self.session_dataloaders.items():
             # Reset sampler position
             sampler = dataloader.batch_sampler
             if hasattr(sampler, 'set_position'):
                 sampler.set_position(self.session_positions[session_name])
-
-        # Create iterators for each session. NOTE: Calling `iter(dl)` actually increments sampler position by 2!
-        session_iterators = {s: iter(dl) for s, dl in self.session_dataloaders.items()}
 
         # Continue until we've gone through one full epoch
         # (i.e., until the longest session is exhausted)
@@ -729,6 +728,9 @@ class FastSessionDataLoader:
                         # Reset iterator and try again. NOTE: `SessionSpecificSampler`
                         #  resets its state automatically when `__iter__` expires.
                         iterator = iter(self.session_dataloaders[session_name])
+                        # HACK: Undo the increment of the sampler position during call to `iter`
+                        if hasattr(iterator._index_sampler, 'set_position'):
+                            iterator._index_sampler.set_position(0)
                         session_iterators[session_name] = iterator
                         yield self._get_next_batch(iterator, session_name)
                     else:

--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -560,7 +560,15 @@ class FastSessionDataLoader:
 
     def __len__(self):
         """Return the total number of batches in an epoch."""
-        return sum(self.batches_per_session.values())
+        if self.cycle_mode == 'active':
+            return sum(self.batches_per_session.values())
+        elif self.cycle_mode == 'max':
+            return self.max_batches_per_session * len(self.session_names)
+        else:
+            raise ValueError(
+                f"Invalid cycle mode: {self.cycle_mode}! "
+                f"Must be one of ['active', 'max']"
+            )
 
     def reset_state(self):
         """Reset the state of the dataloader."""
@@ -687,7 +695,7 @@ class FastSessionDataLoader:
             if hasattr(sampler, 'set_position'):
                 sampler.set_position(self.session_positions[session_name])
 
-        # Create iterators for each session
+        # Create iterators for each session. NOTE: Calling `iter(dl)` actually increments sampler position by 2!
         session_iterators = {s: iter(dl) for s, dl in self.session_dataloaders.items()}
 
         # Continue until we've gone through one full epoch

--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -448,16 +448,16 @@ class SessionBatchSampler(Sampler):
     def get_state(self):
         """Return the state of the sampler (including RNG state)."""
         return {
-            'prv_rng_state': self.prv_rng_state,
-            'consumed_sessions': self.consumed_sessions
+            'prv_rng_state': deepcopy(self.prv_rng_state),
+            'consumed_sessions': deepcopy(self.consumed_sessions)
         }
 
     def set_state(self, state):
         """Restore the state of the sampler (including RNG state)."""
-        self.prv_rng_state = state.get('prv_rng_state')
+        self.prv_rng_state = deepcopy(state.get('prv_rng_state'))
         if self.prv_rng_state is not None:
             self.rng.set_state(self.prv_rng_state)
-        self.consumed_sessions = state.get('consumed_sessions', [])
+        self.consumed_sessions = deepcopy(state.get('consumed_sessions', []))
 
 
 class FastSessionDataLoader:
@@ -587,8 +587,8 @@ class FastSessionDataLoader:
         return {
             'current_batch': self.current_batch,
             'position_in_epoch': self.position_in_epoch,
-            'session_positions': self.session_positions.copy(),
-            'batches_from_session': self.batches_from_session.copy(),
+            'session_positions': deepcopy(self.session_positions),
+            'batches_from_session': deepcopy(self.batches_from_session),
             'active_sessions': list(self.active_sessions),  # Store as list for serialization
             'batch_sampler_state': self.batch_sampler.get_state(),
             'session_sampler_states': {
@@ -616,7 +616,7 @@ class FastSessionDataLoader:
         # Restore session positions
         session_positions = state.get('session_positions')
         if session_positions:
-            self.session_positions = session_positions
+            self.session_positions = deepcopy(session_positions)
 
         # Restore RNG state for the batch sampler
         batch_sampler_state = state.get('batch_sampler_state')
@@ -693,7 +693,7 @@ class FastSessionDataLoader:
             #  manually re-set the position to the pre-iteration value!
             _pre_iter_position = dl.batch_sampler.position
             session_iterators[s] = iter(dl)
-            dl.batch_sampler.set_position(_pre_iter_position)
+            dl.batch_sampler.position = _pre_iter_position
 
         # Reset iterators with current positions
         for session_name, dataloader in self.session_dataloaders.items():
@@ -736,6 +736,7 @@ class FastSessionDataLoader:
                         # HACK: Undo the increment of the sampler position during call to `iter`
                         if hasattr(iterator._index_sampler, 'set_position'):
                             iterator._index_sampler.set_position(0)
+                        self.session_positions[session_name] = 0
                         session_iterators[session_name] = iterator
                         yield self._get_next_batch(iterator, session_name)
                     else:
@@ -789,7 +790,16 @@ class SessionSpecificSampler(Sampler):
 
     def set_position(self, position: int):
         """Set the current batch position."""
-        self.position = position % self.num_batches if self.num_batches > 0 else 0
+        # NOTE: We set the position to the number of batches here such that the iterator
+        #  will get exhausted and reset on the next call to `__iter__`. This is neccessary
+        #  because when position == num_batches, we still haven't shuffled the indices, so
+        #  we don't want to reset the position yet.
+        if position == self.num_batches:
+            self.position = self.num_batches
+        elif self.num_batches > 0:
+            self.position = position % self.num_batches
+        else:
+            self.position = 0
 
     def shuffle_indices(self):
         """Shuffle the indices."""
@@ -812,13 +822,13 @@ class SessionSpecificSampler(Sampler):
         # NOTE: We don't save the indices! This requires that the reloaded sampler must be
         #  initialized with the same indices *in the same order* as the original one.
         return {
-            'prv_rng_state': self.prv_rng_state,
+            'prv_rng_state': deepcopy(self.prv_rng_state),
             'position': self.position,
         }
 
     def set_state(self, state):
         """Restore the state of the sampler (including RNG state)."""
-        self.prv_rng_state = state.get('prv_rng_state')
+        self.prv_rng_state = deepcopy(state.get('prv_rng_state'))
         if self.prv_rng_state is not None:
             self.rng.set_state(self.prv_rng_state)
             # shuffle indices with loaded RNG state

--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -477,7 +477,7 @@ class FastSessionDataLoader:
         num_workers=0,
         pin_memory=False,
         drop_last=False,
-        cycle_mode: Literal['active', 'max'] = 'active',
+        cycle_mode: Literal['active', 'balanced'] = 'active',
         seed=None,
         **kwargs,
     ):
@@ -502,8 +502,8 @@ class FastSessionDataLoader:
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.kwargs = kwargs
-        assert cycle_mode in ['active', 'max'], \
-            f"Invalid cycle mode: {cycle_mode}! Must be one of ['active', 'max']"
+        assert cycle_mode in ['active', 'balanced'], \
+            f"Invalid cycle mode: {cycle_mode}! Must be one of ['active', 'balanced']"
         self.cycle_mode = cycle_mode
         # Create batch sampler
         self.batch_sampler = SessionBatchSampler(
@@ -562,12 +562,12 @@ class FastSessionDataLoader:
         """Return the total number of batches in an epoch."""
         if self.cycle_mode == 'active':
             return sum(self.batches_per_session.values())
-        elif self.cycle_mode == 'max':
+        elif self.cycle_mode == 'balanced':
             return self.max_batches_per_session * len(self.session_names)
         else:
             raise ValueError(
                 f"Invalid cycle mode: {self.cycle_mode}! "
-                f"Must be one of ['active', 'max']"
+                f"Must be one of ['active', 'balanced']"
             )
 
     def reset_state(self):
@@ -724,7 +724,7 @@ class FastSessionDataLoader:
                         # This session is exhausted for the current epoch
                         if session_name in self.active_sessions:
                             self.active_sessions.remove(session_name)
-                    elif self.cycle_mode == 'max':
+                    elif self.cycle_mode == 'balanced':
                         # Reset iterator and try again. NOTE: `SessionSpecificSampler`
                         #  resets its state automatically when `__iter__` expires.
                         iterator = iter(self.session_dataloaders[session_name])
@@ -736,7 +736,7 @@ class FastSessionDataLoader:
                     else:
                         raise ValueError(
                             f"Invalid cycle mode: {self.cycle_mode}! "
-                            f"Must be one of ['active', 'max']"
+                            f"Must be one of ['active', 'balanced']"
                         )
 
             self.batch_sampler.consumed_sessions = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+"""
+Pytest configuration and fixtures for testing experanto.utils functionality.
+"""
+
+import pytest
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+@pytest.fixture
+def mock_dataset():
+    """Create a mock dataset for testing data loaders."""
+    class MockDataset(Dataset):
+        def __init__(self, min_length=5, max_length=105, seed=None, session_name=None):
+            self.np_rng = np.random.RandomState(seed)
+            self.torch_rng = torch.Generator()
+            if seed is not None:
+                self.torch_rng.manual_seed(seed)
+            self.length = self.np_rng.randint(min_length, max_length + 1)
+            
+            # Use provided session name or generate one in format #####-#-#
+            if session_name is not None:
+                self.session_name = session_name
+            else:
+                animal_id = self.np_rng.randint(10000, 99999)
+                month = self.np_rng.randint(1, 12)
+                day = self.np_rng.randint(1, 28)
+                self.session_name = f"{animal_id}-{month}-{day}"
+            self.data_key = self.session_name
+            
+            # Pre-generate all batches
+            self.batches = [self._gen_batch() for _ in range(self.length)]
+        
+        def _gen_batch(self):
+            # Generate data tensors
+            responses = torch.randn(60, 4096, generator=self.torch_rng) * 25 + 25
+            screen = torch.randn(1, 60, 36, 64, generator=self.torch_rng) * 2
+            eye_tracker = torch.randn(40, 4, generator=self.torch_rng)
+            treadmill = torch.rand(40, 1, generator=self.torch_rng) * 0.4 + 0.25
+            # Generate timestamps (relative, starting from 0)
+            timestamps = {
+                'responses': torch.rand(60, 4096, generator=self.torch_rng) * 2.0,
+                'screen': torch.rand(60, generator=self.torch_rng) * 2.0,
+                'eye_tracker': torch.rand(40, generator=self.torch_rng) * 2.0,
+                'treadmill': torch.rand(40, generator=self.torch_rng) * 2.0
+            }
+            # Sort timestamps to be monotonic
+            for key in timestamps:
+                timestamps[key], _ = torch.sort(timestamps[key], dim=-1)
+            # Construct batch data
+            batch_data = {
+                    'responses': responses,
+                    'screen': screen,
+                    'eye_tracker': eye_tracker,
+                    'treadmill': treadmill,
+                    'timestamps': timestamps
+                }
+            return batch_data
+            
+        def __len__(self):
+            return self.length
+            
+        def __getitem__(self, idx):
+            return self.batches[idx]
+        
+        def get_state(self):
+            pass
+
+        def set_state(self, state):
+            pass
+
+        def reset_state(self):
+            pass
+    
+    return MockDataset

--- a/tests/test_session_dataloaders.py
+++ b/tests/test_session_dataloaders.py
@@ -1,0 +1,807 @@
+"""
+Tests for SessionBatchSampler, SessionSpecificSampler, and FastSessionDataLoader functionality.
+"""
+import pytest
+from copy import deepcopy
+from collections import defaultdict, Counter
+import numpy as np
+import torch
+
+from experanto.utils import (
+    count_batches,
+    SessionConcatDataset, 
+    SessionBatchSampler, 
+    SessionSpecificSampler, 
+    FastSessionDataLoader
+)
+
+
+def states_equal(state1, state2):
+    """
+    Compare two nested state dictionaries that may contain numpy arrays.
+    
+    This handles the case where RNG states contain numpy arrays that can't be
+    compared directly with == due to ambiguous truth values.
+    """
+    if type(state1) != type(state2):
+        return False
+    
+    if isinstance(state1, dict):
+        if set(state1.keys()) != set(state2.keys()):
+            return False
+        return all(states_equal(state1[k], state2[k]) for k in state1.keys())
+    
+    elif isinstance(state1, (list, tuple)):
+        if len(state1) != len(state2):
+            return False
+        return all(states_equal(a, b) for a, b in zip(state1, state2))
+    
+    elif isinstance(state1, np.ndarray):
+        return isinstance(state2, np.ndarray) and np.array_equal(state1, state2)
+    
+    else:
+        # For primitives and other types
+        return state1 == state2
+
+
+def _check_reset(_fast_dataloader: FastSessionDataLoader):
+    """Utility function to check that dataloader state was reset."""
+    assert _fast_dataloader.current_batch == 0
+    assert _fast_dataloader.position_in_epoch == 0
+    assert all(p == 0 for p in _fast_dataloader.session_positions.values())
+    assert all(dl.batch_sampler.position == 0 for dl in _fast_dataloader.session_dataloaders.values())
+    assert all(p == 0 for p in _fast_dataloader.batches_from_session.values())
+    assert len(_fast_dataloader.active_sessions) == len(_fast_dataloader.session_dataloaders)
+    assert len(_fast_dataloader.batch_sampler.consumed_sessions) == 0
+
+
+@pytest.fixture
+def test_datasets(
+    mock_dataset,
+    seed: int = 42,
+):
+    """Create test datasets with different lengths using the conftest MockDataset."""
+    # Create datasets with specific lengths and fixed session names for testing
+    datasets = [
+        mock_dataset(min_length=5, max_length=5, seed=seed, session_name="session_a"),  # Length 5
+        mock_dataset(min_length=8, max_length=8, seed=(seed + 1), session_name="session_b"),  # Length 8
+        mock_dataset(min_length=10, max_length=10, seed=(seed + 2), session_name="session_c") # Length 10
+    ]
+    
+    session_names = ["session_a", "session_b", "session_c"]
+    return datasets, session_names
+
+
+@pytest.fixture
+def concat_dataset(test_datasets):
+    """Create a SessionConcatDataset from test datasets."""
+    datasets, session_names = test_datasets
+    return SessionConcatDataset(datasets, session_names)
+
+
+@pytest.fixture
+def batch_sampler_factory(concat_dataset):
+    def _factory(
+        batch_size: int = 2,
+        drop_last: bool = False,
+        shuffle: bool = True,
+        seed: int = 12345,
+    ):
+        return SessionBatchSampler(
+            dataset=concat_dataset,
+            batch_size=batch_size,
+            drop_last=drop_last,
+            shuffle=shuffle,
+            seed=seed
+        )
+    return _factory
+
+
+@pytest.fixture
+def session_specific_sampler_factory(
+    batch_sampler_factory,
+):
+    """A factory to create session-specific samplers."""
+    def _factory(
+        shuffle: bool = True,
+        session_name: str = 'session_a',
+        seed: int = 12345,
+    ):
+        batch_sampler = batch_sampler_factory(
+            shuffle=shuffle,
+            seed=seed
+        )
+        assert session_name in batch_sampler.session_names, (
+            f"Session name {session_name} not found in batch sampler"
+        )
+        return SessionSpecificSampler(
+            indices=batch_sampler.session_indices[session_name],
+            batch_size=batch_sampler.batch_size,
+            drop_last=batch_sampler.drop_last,
+            shuffle=batch_sampler.shuffle,
+            seed=seed
+        )
+    return _factory
+
+
+@pytest.fixture
+def fast_dataloader_factory(concat_dataset):
+    """A factory to create FastSessionDataLoader"""
+    def _factory(
+        batch_size: int = 2,
+        drop_last: bool = False,
+        shuffle: bool = True,
+        cycle_mode: str = 'balanced',
+        seed: int = 12345,
+    ):
+        return FastSessionDataLoader(
+            dataset=concat_dataset,
+            batch_size=batch_size,
+            drop_last=drop_last,
+            shuffle=shuffle,
+            cycle_mode=cycle_mode,
+            seed=seed
+        )
+    return _factory
+
+
+class TestSessionConcatDataset:
+    """Test SessionConcatDataset functionality."""
+    
+    def test_basic_functionality(self, test_datasets, concat_dataset):
+        """Test basic SessionConcatDataset operations."""
+        _, session_names = test_datasets
+
+        # Check total length
+        assert len(concat_dataset) == 5 + 8 + 10  # 23
+        
+        # Check session names
+        assert concat_dataset.session_names == session_names
+        
+        # Check session indices mapping
+        expected_indices = {
+            "session_a": (0, 5),
+            "session_b": (5, 13), 
+            "session_c": (13, 23)
+        }
+        assert concat_dataset.session_indices == expected_indices
+    
+    def test_get_session_for_idx(self, concat_dataset):
+        """Test session retrieval by index."""
+        # Test various indices
+        assert concat_dataset.get_session_for_idx(0) == "session_a"
+        assert concat_dataset.get_session_for_idx(4) == "session_a"
+        assert concat_dataset.get_session_for_idx(5) == "session_b"
+        assert concat_dataset.get_session_for_idx(12) == "session_b"
+        assert concat_dataset.get_session_for_idx(13) == "session_c"
+        assert concat_dataset.get_session_for_idx(22) == "session_c"
+
+
+class TestSessionBatchSampler:
+    """Test SessionBatchSampler functionality."""
+    
+    def test_initialization(self, concat_dataset, batch_sampler_factory):
+        """Test SessionBatchSampler initialization."""
+        # Create batch sampler
+        batch_sampler = batch_sampler_factory()
+
+        assert batch_sampler.session_names == ["session_a", "session_b", "session_c"]
+
+        session_indices = list(map(lambda x: list(range(*x)), concat_dataset.session_indices.values()))
+        session_a_batches = count_batches(session_indices[0], 2, False)
+        session_b_batches = count_batches(session_indices[1], 2, False)
+        session_c_batches = count_batches(session_indices[2], 2, False)
+        assert len(batch_sampler) == (
+            session_a_batches + session_b_batches + session_c_batches
+        )
+        
+        # Check batches per session
+        expected_batches = {
+            "session_a": session_a_batches,
+            "session_b": session_b_batches,
+            "session_c": session_c_batches
+        }
+        assert batch_sampler.batches_per_session == expected_batches
+    
+    def test_session_cycle_generation(self, batch_sampler_factory):
+        """Test session cycle order generation."""
+        # Create batch sampler
+        batch_sampler = batch_sampler_factory()
+
+        # Get multiple cycles - should be shuffled but contain all sessions
+        cycle1 = batch_sampler.get_session_cycle()
+        cycle2 = batch_sampler.get_session_cycle()
+        
+        # Each cycle should contain all sessions
+        assert set(cycle1) == {"session_a", "session_b", "session_c"}
+        assert set(cycle2) == {"session_a", "session_b", "session_c"}
+        
+        # With different random states, order should be different (though with small
+        #  sample, might occasionally be same, so we check 100 times). Also check that
+        #  RNG state changes on each call to `get_session_cycle`.
+        shuffle_flag = False
+        prev_cycle = cycle2
+        for _ in range(100):
+            prev_prv_rng_state = deepcopy(batch_sampler.prv_rng_state)
+            curr_cycle = batch_sampler.get_session_cycle()
+            next_prv_rng_state = deepcopy(batch_sampler.prv_rng_state)
+            assert (not all([np.array(s1 == s2).all() for s1, s2 in zip(
+                next_prv_rng_state, prev_prv_rng_state
+            )])), "RNG state did not change on call to `get_session_cycle`"
+            if not all(p == c for c, p in zip(curr_cycle, prev_cycle)):
+                shuffle_flag = True
+                break  # Order has changed, shuffling is working.
+            prev_cycle = curr_cycle
+        # This block executes if the loop completes without a `break`.
+        assert shuffle_flag, (
+            "Session cycle order did not change over 100 consecutive "
+            "generations, suggesting that shuffling is not working."
+        )
+
+
+class TestSessionSpecificSampler:
+    """Test SessionSpecificSampler functionality."""
+    
+    def test_basic_functionality(self, session_specific_sampler_factory):
+        """Test basic SessionSpecificSampler operations."""
+        # Create a sampler using the factory
+        sampler = session_specific_sampler_factory(shuffle=False)
+
+        assert (
+            len(sampler) == 
+            sampler.num_batches == 
+            count_batches(
+                sampler.indices,
+                sampler.batch_size,
+                sampler.drop_last
+            )
+        )
+    
+    def test_iteration_without_shuffle(self, session_specific_sampler_factory):
+        """Test iteration without shuffling."""
+        # Create a sampler using the factory with batch_size=1 for predictable testing
+        sampler = session_specific_sampler_factory(shuffle=False)
+
+        # Collect all batches of indices
+        batches = list(sampler)
+        
+        # The sampler should return indices from session_a (which are [0,1,2,3,4] in the concat dataset)
+        # With batch_size=2, we expect: [[0,1], [2,3], [4]]
+        expected_batches = [[0, 1], [2, 3], [4]]
+        assert batches == expected_batches
+    
+    def test_state_management(self, session_specific_sampler_factory):
+        """Test state save/load functionality."""
+        sampler = session_specific_sampler_factory()
+        
+        # Get initial state
+        initial_state = sampler.get_state()
+        
+        # Consume some batches
+        iterator = iter(sampler)
+        batch1 = next(iterator)
+        batch2 = next(iterator)
+        
+        # Save state after consuming 2 batches
+        mid_state = sampler.get_state()
+        assert mid_state['position'] == 2
+        
+        # Continue and collect remaining batches
+        remaining_batches_original = list(iterator)
+        
+        # Create new sampler and restore state
+        new_sampler = session_specific_sampler_factory(
+            seed=11111  # Different seed to ensure state restoration works
+        )
+        new_sampler.set_state(mid_state)
+        
+        # Get remaining batches from restored sampler
+        remaining_batches_restored = list(new_sampler)
+        
+        # Should match exactly
+        assert remaining_batches_original == remaining_batches_restored
+
+
+class TestBalancedFastSessionDataLoader:
+    """Test FastSessionDataLoader functionality with cycle_mode='balanced'."""
+    
+    def test_initialization(self, fast_dataloader_factory):
+        """Test FastSessionDataLoader initialization."""
+        fast_dataloader = fast_dataloader_factory(batch_size=1)
+        assert len(fast_dataloader.session_names) == 3
+        assert fast_dataloader.cycle_mode == 'balanced'
+        assert fast_dataloader.max_batches_per_session == 10
+        # Total batches should be 3 sessions * 10 max_batches = 30
+        assert len(fast_dataloader) == 30
+    
+    def test_main_behavior_cycle_max(self, fast_dataloader_factory):
+        """Test main expected behavior with cycle_mode='balanced'."""
+        fast_dataloader = fast_dataloader_factory(batch_size=1)
+        # Collect all batches from one epoch
+        epoch_batches = []
+        session_batch_count = defaultdict(int)
+        
+        for session_name, batch_data in fast_dataloader:
+            epoch_batches.append((session_name, batch_data))
+            session_batch_count[session_name] += 1
+        
+        # Should have exactly 30 batches total (3 * 10)
+        assert len(epoch_batches) == 30
+        
+        # Each session should appear exactly 10 times
+        assert session_batch_count["session_a"] == 10
+        assert session_batch_count["session_b"] == 10  
+        assert session_batch_count["session_c"] == 10
+        
+        # Verify that every 3 consecutive batches contain exactly one from each session
+        for i in range(0, 30, 3):
+            # Get sessions for batches i, i+1, i+2
+            cycle_sessions = {epoch_batches[i][0], epoch_batches[i+1][0], epoch_batches[i+2][0]}
+            assert cycle_sessions == {"session_a", "session_b", "session_c"}
+    
+    def test_shorter_datasets_repeat(self, fast_dataloader_factory):
+        """Test that shorter datasets repeat their data when exhausted."""
+        fast_dataloader = fast_dataloader_factory(batch_size=1)
+        # Track data from session_a (length=5) across the full epoch
+        session_batches = defaultdict(list)
+        session_responses_hashes = defaultdict(list)
+        
+        for session_name, batch_data in fast_dataloader:
+            # Use hash of responses tensor to identify unique batches
+            responses_hash = hash(batch_data['responses'].flatten().tolist().__str__())
+            session_batches[session_name].append(batch_data)
+            session_responses_hashes[session_name].append(responses_hash)
+        
+        # Should have 5 batches from the all sessions
+        assert all(len(sb) == 10 for sb in session_batches.values())
+        
+        # Since shortest session only has 5 unique batches, some should repeat
+        for session_name, session_hashes in session_responses_hashes.items():
+            expected_batches = len(fast_dataloader.session_dataloaders[session_name])
+            assert len(set(session_hashes)) == expected_batches
+            hash_counts = Counter(session_hashes)
+            assert sum(hash_counts.values()) == 10
+            # shortest session should have exactly 2 batches per hash
+            if session_name == "session_a":
+                assert all(count == 2 for count in hash_counts.values())
+            # middle session should have 1-2 batches per hash
+            elif session_name == "session_b":
+                assert all(1 <= count <= 2 for count in hash_counts.values())
+            # longest session should have exactly 1 batch per hash
+            elif session_name == "session_c":
+                assert all(count == 1 for count in hash_counts.values())
+    
+    def test_synced_epoch_reset_behavior(self, fast_dataloader_factory):
+        """Test that dataloader resets after epoch completion.
+        
+        TODO: Consider adding a few more validation checks
+        """
+        # Create dataloader and get synced length
+        fast_dataloader = fast_dataloader_factory()
+        # Create extended length (imitating 
+        #  `unraveling.distributed.utils.SyncedFastSessionDataLoader`)
+        synced_len = int(len(fast_dataloader) * 1.5)
+        # Run for 2 (extended) epochs
+        epochs, global_step = 2, 0
+        while epochs > 0:
+            epoch_step, original_epoch_step = 0, 0
+            session_batch_counts = defaultdict(int)
+            session_batch_hashes = defaultdict(list)
+            dl_iter = iter(fast_dataloader)
+            while epoch_step < synced_len:
+                try:
+                    # Get next batch
+                    key, batch = next(dl_iter)
+                except StopIteration:
+                    # Reset "original" epoch step
+                    original_epoch_step = 0
+                    # Check automatic reset after exhausting iterator
+                    _check_reset(fast_dataloader)
+                    # Reset iterator
+                    dl_iter = iter(fast_dataloader)
+                    # Check that `iter` doesn't affect state
+                    _check_reset(fast_dataloader)
+                    # Get next batch from new iterator
+                    key, batch = next(dl_iter)
+                
+                # Validate `position_in_epoch`. NOTE: `position_in_epoch` incremented only after `yield`.
+                expected_position_in_epoch = original_epoch_step // 3
+                assert expected_position_in_epoch == fast_dataloader.position_in_epoch
+                original_epoch_step += 1
+                epoch_step += 1
+                global_step += 1
+                session_batch_counts[key] += 1
+                session_batch_hashes[key].append(
+                    hash(batch['responses'].flatten().tolist().__str__())
+                )
+                
+                # ===============================================
+                # COMPREHENSIVE TRACKER VALIDATION
+                # ===============================================
+                
+                # FastSessionDataLoader trackers:
+                # 1. current_batch - should match original_epoch_step  
+                assert original_epoch_step == fast_dataloader.current_batch
+                
+                # # 2. position_in_epoch - incremented after full cycle (see above)
+                
+                # 3. batches_from_session - should match actual counts within current epoch
+                max_batches_per_session = fast_dataloader.max_batches_per_session
+                for session_name in fast_dataloader.session_names:
+                    session_batch_count = session_batch_counts[session_name]
+                    if epoch_step > len(fast_dataloader):
+                        session_batch_count = session_batch_count % max_batches_per_session
+                    # NOTE: The batch count doesn't reset until after trying to get the next batch
+                    if session_batch_count > 0 and session_batch_count % max_batches_per_session == 0:
+                        expected_batches_from_session = max_batches_per_session
+                    else:
+                        expected_batches_from_session = session_batch_count % max_batches_per_session
+                    actual_batches_from_session = fast_dataloader.batches_from_session[session_name]
+                    assert expected_batches_from_session == actual_batches_from_session, \
+                        f"Session {session_name}: expected {expected_batches_from_session}, got {actual_batches_from_session}"
+                
+                # 4. session_positions - should match position within each session's cycle
+                for session_name in fast_dataloader.session_names:
+                    session_batch_count = session_batch_counts[session_name]
+                    session_dataloader = fast_dataloader.session_dataloaders[session_name]
+                    session_len = len(session_dataloader)
+                    
+                    # NOTE: The position doesn't reset until after trying to get the next batch
+                    if epoch_step > len(fast_dataloader):
+                        session_batch_count = session_batch_count % max_batches_per_session
+                    if session_batch_count > 0 and session_batch_count % session_len == 0:
+                        expected_session_position = session_len
+                    else:
+                        expected_session_position = session_batch_count % session_len
+                    actual_session_position = fast_dataloader.session_positions[session_name]
+                    assert expected_session_position == actual_session_position, \
+                        f"Session {session_name}: expected position {expected_session_position}, got {actual_session_position}"
+                
+                # 5. active_sessions - should contain all sessions in balanced mode
+                assert len(fast_dataloader.active_sessions) == len(fast_dataloader.session_names)
+                assert fast_dataloader.active_sessions == set(fast_dataloader.session_names)
+                
+                # SessionSpecificSampler trackers (for each session):
+                for session_name, session_dataloader in fast_dataloader.session_dataloaders.items():
+                    session_sampler = session_dataloader.batch_sampler
+                    session_batch_count = session_batch_counts[session_name]
+                    session_len = len(session_dataloader)
+                    
+                    # 1. position - should match the current position within session
+                    if epoch_step > len(fast_dataloader):
+                        session_batch_count = session_batch_count % max_batches_per_session
+                    # NOTE: The position doesn't reset until after trying to get the next batch
+                    if session_batch_count > 0 and session_batch_count % session_len == 0:
+                        expected_sampler_position = session_len
+                    else:
+                        expected_sampler_position = session_batch_count % session_len
+                    actual_sampler_position = session_sampler.position
+                    assert expected_sampler_position == actual_sampler_position, \
+                        f"Session {session_name} sampler: expected position {expected_sampler_position}, got {actual_sampler_position}"
+                
+                # SessionBatchSampler trackers:
+                batch_sampler = fast_dataloader.batch_sampler
+                
+                # 1. consumed_sessions - should track sessions used in current cycle
+                # Length should be between 0-3 (resets after each full cycle)
+                consumed_count = len(batch_sampler.consumed_sessions)
+                assert 0 <= consumed_count <= 3, \
+                    f"consumed_sessions count {consumed_count} should be between 0-3"
+                
+                # The consumed sessions should match the sessions we've seen in current cycle
+                current_cycle_position = original_epoch_step % 3
+                if current_cycle_position == 0:
+                    # Just completed a cycle, should have all 3 sessions or be empty (if just reset)
+                    assert consumed_count in [0, 3], \
+                        f"At cycle boundary, consumed_sessions should be 0 or 3, got {consumed_count}"
+                else:
+                    # In middle of cycle, should match current position
+                    assert consumed_count == current_cycle_position, \
+                        f"In cycle position {current_cycle_position}, consumed_sessions should be {current_cycle_position}, got {consumed_count}"
+                
+                # Cross-validation: session_positions should match sampler positions
+                for session_name in fast_dataloader.session_names:
+                    session_dataloader = fast_dataloader.session_dataloaders[session_name]
+                    sampler_position = session_dataloader.batch_sampler.position
+                    fast_dl_position = fast_dataloader.session_positions[session_name]
+                    assert sampler_position == fast_dl_position, \
+                        f"Session {session_name}: sampler position {sampler_position} != dataloader position {fast_dl_position}"
+
+            # =============================================== 
+            # END OF EPOCH VALIDATION
+            # ===============================================
+            
+            # Validate correct number of batches seen after epoch completion
+            total_batches_seen = sum(session_batch_counts.values())
+            expected_total_batches = synced_len
+            assert total_batches_seen == expected_total_batches, \
+                f"Expected {expected_total_batches} total batches, but saw {total_batches_seen}"
+            
+            # In balanced mode, each session should have been seen the same number of times
+            # across the synced epoch length
+            max_batches_per_session = fast_dataloader.max_batches_per_session
+            expected_cycles = synced_len // 3  # 3 sessions per cycle
+            expected_remainder = synced_len % 3  # remaining batches after complete cycles
+            
+            # For complete cycles, each session should appear exactly 'expected_cycles' times
+            for session_name in fast_dataloader.session_names:
+                actual_count = session_batch_counts[session_name]
+                
+                # Each session appears once per cycle, plus potentially once more if in remainder
+                min_expected = expected_cycles
+                max_expected = expected_cycles + (1 if expected_remainder > 0 else 0)
+                
+                assert min_expected <= actual_count <= max_expected, \
+                    f"Session {session_name}: expected {min_expected}-{max_expected} batches, got {actual_count}"
+            
+            # The total should equal exactly synced_len
+            assert sum(session_batch_counts.values()) == synced_len, \
+                f"Total session batch counts {sum(session_batch_counts.values())} != synced_len {synced_len}"
+            
+            # Validate that we've covered the expected number of full dataloader epochs
+            # synced_len = 1.5 * len(fast_dataloader), so we should see 1 complete epoch + partial
+            full_epochs_expected = synced_len // len(fast_dataloader)
+            partial_epoch_batches = synced_len % len(fast_dataloader)
+            
+            print(f"Epoch completed: saw {total_batches_seen} batches "
+                  f"({full_epochs_expected} full epochs + {partial_epoch_batches} partial batches)")
+            
+            # Validate session distribution within each complete epoch cycle
+            if full_epochs_expected > 0:
+                # In balanced mode, each complete epoch should have exactly max_batches_per_session per session
+                for i in range(full_epochs_expected):
+                    epoch_start = i * len(fast_dataloader)
+                    epoch_end = min((i + 1) * len(fast_dataloader), synced_len)
+                    epoch_batches = epoch_end - epoch_start
+                    
+                    if epoch_batches == len(fast_dataloader):  # Complete epoch
+                        # Each session should appear exactly max_batches_per_session times
+                        for session_name in fast_dataloader.session_names:
+                            # Count batches for this session in this epoch
+                            session_count_in_epoch = 0
+                            # This is simplified - in practice we'd need to track per-epoch
+                            # but since we reset between epochs, we can validate the pattern
+                            if i == 0:  # First epoch (we can validate this one)
+                                expected_in_complete_epoch = max_batches_per_session
+                                # Note: This is a simplified check since we don't track per-epoch history
+                                # The main validation is that total counts are correct
+            
+            # Reset dataloader
+            fast_dataloader.reset_state()
+            # Check that dataloader state was reset
+            _check_reset(fast_dataloader)
+            epochs -= 1
+    
+    def test_state_save_restore(self, fast_dataloader_factory):
+        """Test state save and restore functionality."""
+        fast_dataloader = fast_dataloader_factory(batch_size=1)
+        # Iterate through part of an epoch
+        original_batches = []
+        iterations_before_save = 12  # Save after 12 iterations
+        
+        iterator = iter(fast_dataloader)
+        for _ in range(iterations_before_save):
+            batch = next(iterator)
+            original_batches.append(batch)
+        
+        # Save state
+        saved_state = fast_dataloader.get_state()
+        
+        # Create new dataloader with same configuration
+        new_dataloader = fast_dataloader_factory(batch_size=1)
+        
+        # Restore state
+        new_dataloader.set_state(saved_state)
+        
+        # Continue with original dataloader
+        remaining_original = list(iterator)
+        
+        # Get remaining batches from restored dataloader
+        remaining_restored = list(new_dataloader)
+        
+        # Should match exactly
+        assert len(remaining_original) == len(remaining_restored)
+        
+        # Compare session names and batch data (responses tensor should be identical)
+        for (orig_session, orig_data), (rest_session, rest_data) in zip(remaining_original, remaining_restored):
+            assert orig_session == rest_session
+            # Compare responses tensors (our deterministic mock data)
+            assert torch.equal(orig_data['responses'], rest_data['responses'])
+    
+    def test_iter_behavior_maintains_state(self, fast_dataloader_factory):
+        """Test that calling iter() multiple times doesn't reset state inappropriately."""
+        fast_dataloader = fast_dataloader_factory()
+        # Get initial state
+        initial_state = fast_dataloader.get_state()
+        
+        # Call iter() multiple times
+        iter1 = iter(fast_dataloader)
+        batch1 = next(iter1)
+        iter2 = iter(fast_dataloader)
+        batch2 = next(iter2) 
+        iter3 = iter(fast_dataloader)
+        batch3 = next(iter3)
+        
+        # Should be the same batch (same session and batch data)
+        assert batch1[0] != batch2[0] != batch3[0]  # Different sessions
+        assert all(p == 1 for p in fast_dataloader.session_positions.values())
+        assert all(dl.batch_sampler.position == 1 for dl in fast_dataloader.session_dataloaders.values())
+        assert fast_dataloader.current_batch == 3
+        assert all(bfs == 1 for bfs in fast_dataloader.batches_from_session.values())
+        # NOTE: `position_in_epoch` is incremented only after `yield`
+        assert fast_dataloader.position_in_epoch == 0
+        # TODO: This actually fails because each iterator has it's own `cycle_order` generated!
+        #  This behavior should be modified such that the cycle order is in the underlying state of
+        #  of the batch sampler.
+        # next(iter1)
+        # assert fast_dataloader.position_in_epoch == 1
+    
+    def test_deterministic_behavior_with_seed(self, fast_dataloader_factory):
+        """Test that same seed produces deterministic behavior."""
+        
+        # Create two dataloaders with same seed
+        dl1 = fast_dataloader_factory(seed=99999)
+        dl2 = fast_dataloader_factory(seed=99999)
+        
+        # Get first 10 batches from each
+        batches1 = []
+        batches2 = []
+        
+        for i, ((session1, data1), (session2, data2)) in enumerate(zip(dl1, dl2)):
+            # Use tensor sum as a simple but deterministic hash
+            responses_sum1 = data1['responses'].sum().item()
+            responses_sum2 = data2['responses'].sum().item()
+            batches1.append((session1, responses_sum1))
+            batches2.append((session2, responses_sum2))
+            if i >= 9:  # Get first 10 batches
+                break
+        
+        # Should be identical
+        assert batches1 == batches2
+
+
+class TestIntegrationScenarios:
+    """Integration tests for complex scenarios."""
+    
+    def test_partial_epoch_state_restoration(self, fast_dataloader_factory):
+        """Test state restoration at various points in an epoch."""
+        fast_dataloader = fast_dataloader_factory()
+        checkpoints = [3, 7, 15, 28]  # Various points to test
+        
+        for checkpoint_at in checkpoints:
+            # Reset dataloader
+            fast_dataloader.reset_state()
+            
+            # Iterate to checkpoint
+            original_batches = []
+            iterator = iter(fast_dataloader)
+            for _ in range(checkpoint_at):
+                try:
+                    original_batches.append(next(iterator))
+                except StopIteration:
+                    # Reset iterator
+                    iterator = iter(fast_dataloader)
+                    original_batches.append(next(iterator))
+            
+            # Save state
+            state = fast_dataloader.get_state()
+            
+            # Continue original
+            remaining_original = list(iterator)
+            
+            # Create fresh dataloader and restore
+            new_dataloader = fast_dataloader_factory()
+            new_dataloader.set_state(state)
+            
+            # Get remaining from restored
+            remaining_restored = list(new_dataloader)
+            
+            # Should match
+            assert len(remaining_original) == len(remaining_restored)
+            for (orig_session, orig_data), (rest_session, rest_data) in zip(remaining_original, remaining_restored):
+                assert orig_session == rest_session
+                assert torch.equal(orig_data['responses'], rest_data['responses'])
+    
+    def test_state_save_at_end_of_iterator(self, fast_dataloader_factory):
+        """Test state save/restore behavior when saving at the very end of iteration."""
+        fast_dataloader = fast_dataloader_factory()
+        
+        # Consume all but the last batch
+        iterator = iter(fast_dataloader)
+        all_batches = []
+        
+        # Get all batches except the last one
+        for i in range(len(fast_dataloader) - 1):
+            batch = next(iterator)
+            all_batches.append(batch)
+        
+        # Get the last batch
+        last_batch = next(iterator)
+        all_batches.append(last_batch)
+        
+        # Now we're at the end - save state here
+        end_state = fast_dataloader.get_state()
+        
+        # Verify that trying to get next batch raises StopIteration
+        with pytest.raises(StopIteration):
+            next(iterator)
+        
+        # Create new dataloader and restore the end state
+        new_dataloader = fast_dataloader_factory()
+        new_dataloader.set_state(end_state)
+        
+        # Create iterator from restored dataloader
+        restored_iterator = iter(new_dataloader)
+        
+        # Trying to get next batch should immediately raise StopIteration
+        with pytest.raises(StopIteration):
+            next(restored_iterator)
+        
+        # Verify that both dataloaders are in the same "exhausted" state
+        assert states_equal(fast_dataloader.get_state(), new_dataloader.get_state())
+        # NOTE: Dataloaders should automatically reset state after exhausting iterator
+        _check_reset(fast_dataloader)
+        _check_reset(new_dataloader)
+        
+        # Verify that after reset, both work normally
+        fast_dataloader.reset_state()
+        new_dataloader.reset_state()
+        # NOTE: Verify that dataloader state is still reset
+        _check_reset(fast_dataloader)
+        _check_reset(new_dataloader)
+        
+        # Both should be able to iterate normally after reset
+        first_batch_original = next(iter(fast_dataloader))
+        first_batch_restored = next(iter(new_dataloader))
+        
+        # Should get the same first batch (same seed)
+        assert first_batch_original[0] == first_batch_restored[0]  # Same session
+        assert torch.equal(first_batch_original[1]['responses'], first_batch_restored[1]['responses'])
+    
+    def test_shuffle_indices_behavior(self, fast_dataloader_factory):
+        """Test that shuffle_indices produces different orders but is reproducible with same RNG state."""
+        fast_dataloader = fast_dataloader_factory()
+        
+        # Get a session sampler that uses shuffling
+        session_name = "session_a"
+        session_sampler = fast_dataloader.session_dataloaders[session_name].batch_sampler
+        
+        # Skip test if shuffle is disabled
+        if not session_sampler.shuffle:
+            pytest.skip("Test requires shuffle=True")
+        
+        # Reset to known state
+        session_sampler.reset_state()
+        original_rng_state = session_sampler.prv_rng_state
+        
+        # Get initial shuffled indices
+        first_indices = session_sampler.indices.copy()
+        
+        # Shuffle again - should get different order
+        session_sampler.shuffle_indices()
+        second_indices = session_sampler.indices.copy()
+        
+        # Should be different (with high probability for non-trivial datasets)
+        if len(first_indices) > 2:  # Only test if we have enough indices
+            assert first_indices != second_indices, "Shuffling should produce different order"
+        
+        # Both should contain the same elements (just reordered)
+        assert sorted(first_indices) == sorted(second_indices), "Shuffling should preserve all indices"
+        
+        # Reset RNG to original state and shuffle again
+        session_sampler.rng.set_state(original_rng_state)
+        session_sampler.shuffle_indices()
+        reproduced_indices = session_sampler.indices.copy()
+        
+        # Should match the first shuffled result (reproducible)
+        assert first_indices == reproduced_indices, "Same RNG state should produce same shuffle"
+        
+        # Test that multiple shuffle calls with same RNG state are deterministic
+        session_sampler.rng.set_state(original_rng_state)
+        session_sampler.shuffle_indices()
+        session_sampler.rng.set_state(original_rng_state) 
+        session_sampler.shuffle_indices()
+        final_indices = session_sampler.indices.copy()
+        
+        # Should still match (each shuffle starts from original indices)
+        assert first_indices == final_indices, "Multiple shuffles with same RNG should be identical"


### PR DESCRIPTION
- Added new `cycle_mode` attribute to `FastSessionDataLoader` with two options:
    * `active` - current behavior, where exhausted sessions are ignored until the iterator is reset.
    * `max` - exhausted sessions are immediately reset (i.e. reshuffled and continued) such that an equal number of batches are seen from each session throughout the epoch.
- Move indices shuffle from `__iter__` to `__init__`, `set_state` (if `prv_rng_state` saved), and `reset_state` in `SessionSpecificSampler` to support new cycle mode where the iterator might be reset multiple times per epoch.
- Add position tracking to `SessionSpecificSampler`
- Save initial `prv_rng_state` in `SessionBatchSampler` to preserve random state even when `seed` not provided.
- Remove forced reset of exhausted `SessionSpecificSampler`'s on calls to `FastSessionDataLoader.__iter__` such that state is maintained until the `FastSessionDataLoader` is exhausted or `FastSessionDataLoader.reset_state` is called